### PR TITLE
Add automatic stream reload

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -79,6 +79,7 @@ export class Dashboard extends MithrilComponent {
                     title="Following"
                     streams={this.streams}
                     loading={this.loading}
+                    lastReloadAt={this.lastReloadAt}
                     onReload={() => void this.loadStreams()}
                 />
             </div>

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -10,15 +10,31 @@ import {
 
 export class Dashboard extends MithrilComponent {
     private streams: Stream[] = null;
+    private loading = false;
 
     async oninit(_: m.Vnode<any, this>) {
+        await this.loadStreams();
+    }
+
+    private async loadStreams() {
+        if (this.loading) {
+            return;
+        }
+
         const userId = getUserId();
         if (!userId || !isAuthenticated()) {
             return;
         }
 
-        this.streams = await getStreamsFollowed({ user_id: userId });
+        this.loading = true;
         m.redraw();
+
+        try {
+            this.streams = await getStreamsFollowed({ user_id: userId });
+        } finally {
+            this.loading = false;
+            m.redraw();
+        }
     }
 
     render() {
@@ -32,6 +48,8 @@ export class Dashboard extends MithrilComponent {
                     url="https://www.twitch.tv/directory/following"
                     title="Following"
                     streams={this.streams}
+                    loading={this.loading}
+                    onReload={() => void this.loadStreams()}
                 />
             </div>
         );

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -21,6 +21,7 @@ export class Dashboard extends MithrilComponent {
 
     oncreate(_: m.VnodeDOM<any, this>) {
         document.addEventListener("visibilitychange", this.onVisibilityChange);
+        window.addEventListener("focus", this.onVisibilityChange);
     }
 
     onremove(_: m.VnodeDOM<any, this>) {
@@ -28,6 +29,7 @@ export class Dashboard extends MithrilComponent {
             "visibilitychange",
             this.onVisibilityChange,
         );
+        window.removeEventListener("focus", this.onVisibilityChange);
     }
 
     private shouldAutoReload(now = Date.now()) {

--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -11,7 +11,7 @@ import {
 export class Dashboard extends MithrilComponent {
     private static readonly AUTO_RELOAD_INTERVAL_MS = 5 * 60 * 1000;
 
-    private streams: Stream[] = null;
+    private streams: Stream[] | null = null;
     private loading = false;
     private lastReloadAt: number | null = null;
 

--- a/src/components/icons/refresh-ccw-icon.tsx
+++ b/src/components/icons/refresh-ccw-icon.tsx
@@ -1,0 +1,32 @@
+import m from "mithril";
+import { MithrilComponent } from "~/components/mithril-component";
+
+type Props = {
+    class?: string;
+    title?: string;
+};
+
+export class RefreshCcwIcon extends MithrilComponent<Props> {
+    render({ class: className, title = "Refresh" }: Props) {
+        return (
+            <svg
+                class={className}
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <title>{title}</title>
+                <path d="M21 12a9 9 0 0 0-9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                <path d="M3 3v5h5" />
+                <path d="M3 12a9 9 0 0 0 9 9 9.75 9.75 0 0 0 6.74-2.74L21 16" />
+                <path d="M16 16h5v5" />
+            </svg>
+        );
+    }
+}

--- a/src/components/stream-list.tsx
+++ b/src/components/stream-list.tsx
@@ -1,4 +1,6 @@
 import m from "mithril";
+import { Button } from "~/components/button";
+import { RefreshCcwIcon } from "~/components/icons/refresh-ccw-icon";
 import { Link } from "~/components/link";
 import { MithrilComponent } from "~/components/mithril-component";
 import { Spinner } from "~/components/spinner";
@@ -10,6 +12,8 @@ type Props = {
     url: string;
     title: string;
     streams: Stream[] | null;
+    loading: boolean;
+    onReload: () => void;
 };
 
 export class StreamList extends MithrilComponent<Props> {
@@ -24,10 +28,24 @@ export class StreamList extends MithrilComponent<Props> {
                     >
                         {props.title}
                     </Link>
-                    <Spinner visible={!props.streams} />
+                    <Button
+                        aria-label="Reload streams"
+                        class={cn("opacity-60 self-center", {
+                            hidden: props.loading,
+                        })}
+                        onclick={props.onReload}
+                        title="Reload streams"
+                    >
+                        <RefreshCcwIcon
+                            class="size-[16px]"
+                            title="Reload streams"
+                        />
+                    </Button>
+                    <Spinner visible={props.loading} />
                     <div
                         class={cn("font-bold opacity-60", {
-                            hidden: props.streams?.length !== 0,
+                            hidden:
+                                props.loading || props.streams?.length !== 0,
                         })}
                     >
                         no streams found

--- a/src/components/stream-list.tsx
+++ b/src/components/stream-list.tsx
@@ -5,9 +5,9 @@ import { Link } from "~/components/link";
 import { MithrilComponent } from "~/components/mithril-component";
 import { Spinner } from "~/components/spinner";
 import { StreamCard } from "~/components/stream-card";
+import { timeSince } from "~/lib/time-since";
 import { Stream } from "~/lib/twitch";
 import { cn } from "~/lib/utils";
-import { timeSince } from "~/lib/time-since";
 
 type Props = {
     url: string;
@@ -78,5 +78,5 @@ function getReloadTitle(lastReloadAt: number | null) {
         return "Reload streams";
     }
 
-    return `Reload streams (last reloaded ${timeSince(lastReloadAt)})`
+    return `Reload streams (last reloaded ${timeSince(lastReloadAt)})`;
 }

--- a/src/components/stream-list.tsx
+++ b/src/components/stream-list.tsx
@@ -7,17 +7,28 @@ import { Spinner } from "~/components/spinner";
 import { StreamCard } from "~/components/stream-card";
 import { Stream } from "~/lib/twitch";
 import { cn } from "~/lib/utils";
+import { timeSince } from "~/lib/time-since";
 
 type Props = {
     url: string;
     title: string;
     streams: Stream[] | null;
     loading: boolean;
+    lastReloadAt: number | null;
     onReload: () => void;
 };
 
 export class StreamList extends MithrilComponent<Props> {
     render(props: Props) {
+        const reloadTitle = getReloadTitle(props.lastReloadAt);
+        const updateReloadTitleOnHover = (
+            event: MouseEvent & {
+                currentTarget: EventTarget & HTMLButtonElement;
+            },
+        ) => {
+            event.currentTarget.title = getReloadTitle(props.lastReloadAt);
+        };
+
         return (
             <div class="flex flex-col">
                 <div class="flex items-end gap-2">
@@ -34,11 +45,12 @@ export class StreamList extends MithrilComponent<Props> {
                             hidden: props.loading,
                         })}
                         onclick={props.onReload}
-                        title="Reload streams"
+                        onmouseenter={updateReloadTitleOnHover}
+                        title={reloadTitle}
                     >
                         <RefreshCcwIcon
                             class="size-[16px]"
-                            title="Reload streams"
+                            title={reloadTitle}
                         />
                     </Button>
                     <Spinner visible={props.loading} />
@@ -59,4 +71,12 @@ export class StreamList extends MithrilComponent<Props> {
             </div>
         );
     }
+}
+
+function getReloadTitle(lastReloadAt: number | null) {
+    if (!lastReloadAt) {
+        return "Reload streams";
+    }
+
+    return `Reload streams (last reloaded ${timeSince(lastReloadAt)})`
 }

--- a/src/components/stream-list.tsx
+++ b/src/components/stream-list.tsx
@@ -30,7 +30,7 @@ export class StreamList extends MithrilComponent<Props> {
                     </Link>
                     <Button
                         aria-label="Reload streams"
-                        class={cn("opacity-60 self-center", {
+                        class={cn("self-center opacity-60", {
                             hidden: props.loading,
                         })}
                         onclick={props.onReload}

--- a/src/lib/time-since.ts
+++ b/src/lib/time-since.ts
@@ -1,0 +1,24 @@
+export function timeSince(time: number) {
+    const elapsedMs = Math.max(0, Date.now() - time);
+    if (elapsedMs < 5_000) {
+        return "just now";
+    }
+
+    if (elapsedMs < 60_000) {
+        const seconds = Math.floor(elapsedMs / 1_000);
+        return `${seconds}s ago`;
+    }
+
+    if (elapsedMs < 3_600_000) {
+        const minutes = Math.floor(elapsedMs / 60_000);
+        return `${minutes}m ago`;
+    }
+
+    if (elapsedMs < 86_400_000) {
+        const hours = Math.floor(elapsedMs / 3_600_000);
+        return `${hours}h ago`;
+    }
+
+    const days = Math.floor(elapsedMs / 86_400_000);
+    return `${days}d ago`;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard auto-refreshes stream data when the tab is active (interval-based, triggers on visibility/focus).
  * Manual refresh button to reload streams on demand, with loading spinner while updating.
  * Hover/tooltip shows human-friendly "last refreshed" time.
  * New refresh icon used in the UI for the reload control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->