### PR TITLE
Add cashbusting to thumbnails

### DIFF
--- a/src/components/dashboard.tsx
+++ b/src/components/dashboard.tsx
@@ -61,6 +61,11 @@ export class Dashboard extends MithrilComponent {
         try {
             this.streams = await getStreamsFollowed({ user_id: userId });
             this.lastReloadAt = Date.now();
+
+            const cacheVersion = `?d=${this.lastReloadAt}`;
+            this.streams.forEach((stream) => {
+                stream.thumbnail_url += cacheVersion;
+            });
         } finally {
             this.loading = false;
             m.redraw();


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream thumbnail caching to ensure users see the latest images when streams reload, preventing stale cached content from appearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->